### PR TITLE
feat: Propagate liveness data when face is first detected

### DIFF
--- a/FaceLivenessDemo/FaceLivenessDemo/ContentView.swift
+++ b/FaceLivenessDemo/FaceLivenessDemo/ContentView.swift
@@ -9,20 +9,61 @@ import SwiftUI
 import FaceLivenessDetection
 
 struct ContentView: View {
-    @State private var model: LivenessDataModel?
+    @State private var faceDataModel: LivenessDataModel?
+    @State private var livenessDataModel: LivenessDataModel?
+
     var body: some View {
-        NavigationView {
-            FaceLivenessDetectionView { result in
-                switch result {
-                case .success(let model):
-                    debugPrint(model.liveness.rawValue, "liveness result")
-                    self.model = model
-                case .failure(let error):
-                    debugPrint(error.localizedDescription)
-                }
+        VStack {
+            FaceLivenessDetectionView(onFaceDetectedCompletion: handleFaceDetectedCompletion, onCompletion: handleLivenessDetectionCompletion)
+
+            if let faceDataModel {
+                PreviewImageView(model: faceDataModel)
+            }
+
+            if let livenessDataModel {
+                PreviewImageView(model: livenessDataModel)
             }
         }
+    }
 
+    private func handleFaceDetectedCompletion(_ result: Result<LivenessDataModel, LivenessDetectionError>) {
+        switch result {
+            case .success(let model):
+                faceDataModel = model
+            case .failure(let error):
+                debugPrint(error)
+        }
+    }
+
+    private func handleLivenessDetectionCompletion(_ result: Result<LivenessDataModel, LivenessDetectionError>) {
+        switch result {
+            case .success(let model):
+                livenessDataModel = model
+            case .failure(let error):
+                debugPrint(error)
+        }
+    }
+}
+
+struct PreviewImageView: View {
+    let model: LivenessDataModel
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Text(model.liveness.rawValue) + Text("  \(model.confidence * 100)%")
+            HStack(spacing: 16) {
+                Image(uiImage: model.capturedImage)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 100)
+
+                Image(uiImage: model.depthImage)
+                    .resizable()
+                    .scaledToFit()
+                    .rotationEffect(.degrees(90))
+                    .frame(width: 100)
+            }
+        }
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ FaceLivenessDetection is a Swift package that provides a framework for detecting
 
 ## Demo
 
-[![Liveness Demo](https://github.com/9count/FaceLivenessDetection/assets/82346532/b05c7c44-ff84-4511-bd31-2ca606d060eb)](https://github.com/9count/FaceLivenessDetection/assets/82346532/7fdf3f4e-6d74-4f57-a333-2bf614512ade)
+[![Liveness Demo](https://github.com/user-attachments/assets/13fb902c-5b4a-4d0a-a04f-3b93972484a4)](https://github.com/user-attachments/assets/13fb902c-5b4a-4d0a-a04f-3b93972484a4)
 
 ## Usage
 

--- a/Sources/FaceLivenessDetection/UI/Components/FaceDetectionViewController.swift
+++ b/Sources/FaceLivenessDetection/UI/Components/FaceDetectionViewController.swift
@@ -90,6 +90,10 @@ final class FaceDetectionViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        sessionQueue.async { [weak self] in
+            guard let self else { return }
+            self.configureCaptureSession()
+        }
         resumeCaptureSession()
     }
 

--- a/Sources/FaceLivenessDetection/UI/FaceDetectionViewModel.swift
+++ b/Sources/FaceLivenessDetection/UI/FaceDetectionViewModel.swift
@@ -21,6 +21,9 @@ public final class FaceDetectionViewModel: ObservableObject {
         }
     }
 
+    /// Stores the face detected liveness results from the liveness detection model.
+    @Published public var faceDetectedResult: LivenessDataModel?
+
     /// Stores the prediction results from the liveness detection model.
     @Published public var predictionResult: LivenessDataModel?
     /// Controls the visibility of the camera preview layer. (For Debug)
@@ -47,6 +50,7 @@ public final class FaceDetectionViewModel: ObservableObject {
     public func reset() {
         instruction = .noFace
         predictionResult = nil
+        faceDetectedResult = nil
         canAnalyzeFace = false
         showProgress = false
     }

--- a/Sources/FaceLivenessDetection/UI/FaceLivenessDetectionView.swift
+++ b/Sources/FaceLivenessDetection/UI/FaceLivenessDetectionView.swift
@@ -21,6 +21,9 @@ public struct FaceLivenessDetectionView: View {
     /// The time interval for the fake verifying loading progress UI.
     var timeInterval: TimeInterval
 
+    /// Completion handler to be called when face is first detected during the current session.
+    var onFaceDetectedCompletion: CompletionHandler?
+
     /// Completion handler to be called with the result of the liveness detection.
     var onCompletion: CompletionHandler
 
@@ -31,7 +34,9 @@ public struct FaceLivenessDetectionView: View {
     ///   - onCompletion: The completion handler to call with the detection result.
     public init(
         timeInterval: TimeInterval = 3,
+        onFaceDetectedCompletion: CompletionHandler? = nil,
         onCompletion: @escaping CompletionHandler) {
+        self.onFaceDetectedCompletion = onFaceDetectedCompletion
         self.onCompletion = onCompletion
         self.timeInterval = timeInterval
     }
@@ -50,11 +55,12 @@ public struct FaceLivenessDetectionView: View {
                         UIScreen.main.brightness = 1.0
                     }
                 })
+                .onReceive(viewModel.$faceDetectedResult) { result in
+                    guard let result else { return }
+                    onFaceDetectedCompletion?(.success(result))
+                }
                 .onReceive(viewModel.$predictionResult, perform: { result in
-                    guard let result else {
-                        return
-                    }
-
+                    guard let result else { return }
                     onCompletion(.success(result))
                     resetDetectionFlow()
                 })


### PR DESCRIPTION
- [X] Set up a closure that can propagate captured face information when face is first detected in a session. (For later liveness model training)

- Additionally, fixed a bug related to ticket [WFC-9794 Camera gets stuck after putting app to background](https://9count.atlassian.net/browse/WFC-9794).